### PR TITLE
cryptography-vectors 3.4.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.4.7" %}
+{% set version = "3.4.8" %}
 
 package:
   name: cryptography-vectors
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
-  sha256: a7ac3aaa57514687696ad65f833e5e39b6fa3c5d41de2b8c938346ee119204c2
+  sha256: 4c84410257993d3de058b44b777a49e1da2ae35ebea2970a360c7e3aa0f580f2
 
 build:
   number: 0


### PR DESCRIPTION
Update cryptography-vectors to 3.4.8