### PR TITLE
Update to 36.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.4.8" %}
+{% set version = "36.0.0" %}
 
 package:
   name: cryptography-vectors
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 4c84410257993d3de058b44b777a49e1da2ae35ebea2970a360c7e3aa0f580f2
+  sha256: c6b7e53ec701f47497297cfcfbafdf81a3f76f6f9d684721ef3dea254301faa5
 
 build:
   number: 0
@@ -17,16 +17,21 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python
+    - python >=3.6
 
 test:
+  requires:
+    - python <3.10
   imports:
     - cryptography_vectors
 
 about:
   home: https://github.com/pyca/cryptography
   license: BSD-3-Clause OR Apache-2.0
+  license_family: BSD
   license_file:
     - LICENSE
     - LICENSE.BSD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-
 {% set version = "36.0.0" %}
 
 package:


### PR DESCRIPTION
Version change: bump version number from 35.0.0 to 36.0.0 (Major version bump!)
Requirements from conda-forge: https://github.com/conda-forge/cryptography-vectors-feedstock/blob/master/recipe/meta.yaml
Setup file: https://github.com/pyca/cryptography/blob/36.0.0/vectors/setup.cfg

The package cryptography-vectors is mentioned inside the packages:
cryptography | 

Actions:
1. Fix python in run

Result:
- all-succeeded