### PR TITLE
cryptography-vectors 36.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "36.0.0" %}
+{% set version = "36.0.1" %}
 
 package:
   name: cryptography-vectors
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
-  sha256: c6b7e53ec701f47497297cfcfbafdf81a3f76f6f9d684721ef3dea254301faa5
+  sha256: fc8490afd5424342b868215435bd174dcd76ab396b4ea9435498be5721dcd598
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "cryptography-vectors" %}
 {% set version = "36.0.1" %}
 
 package:
-  name: cryptography-vectors
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
   sha256: fc8490afd5424342b868215435bd174dcd76ab396b4ea9435498be5721dcd598
 
 build:
@@ -24,7 +25,9 @@ requirements:
 
 test:
   requires:
-    - python <3.10
+    - pip
+  commands:
+    - pip check
   imports:
     - cryptography_vectors
 


### PR DESCRIPTION
Update cryptography-vectors to 36.0.1

Changelog: https://github.com/pyca/cryptography/blob/36.0.1/CHANGELOG.rst#3601---2021-12-14
Setup file: https://github.com/pyca/cryptography/blob/36.0.1/vectors/setup.cfg

The package cryptography-vectors is mentioned inside the packages:
cryptography | 

Actions:
1. Use jinja2 templates in source/url
2. Remove `python `from test/requires
2. Add `pip check`

Result:
- all-succeeded