### PR TITLE
cryptography-vectors 36.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "36.0.1" %}
+{% set version = "36.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: fc8490afd5424342b868215435bd174dcd76ab396b4ea9435498be5721dcd598
+  sha256: 2a7924449a03025faf7f8754a6f4200001cab210734a6ce6ac1f6bdacd3a68e4
 
 build:
   number: 0


### PR DESCRIPTION
Update cryptography-vectors to 36.0.2