### PR TITLE
cryptography-vectors to 37.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "36.0.1" %}
+{% set version = "37.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: fc8490afd5424342b868215435bd174dcd76ab396b4ea9435498be5721dcd598
+  sha256: 66c9a714232be730fe822bd7e4e9da6231ff9e537ee4feb0f092c06b8ea4d94a
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
     - LICENSE.APACHE
   summary: Test vectors for the cryptography package.
   dev_url: https://github.com/pyca/cryptography/tree/master/vectors
-  doc_url: https://cryptography.io
+  doc_url: https://cryptography.io/en/{{ version }}/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update cryptography-vectors to 37.0.1

Jira: https://anaconda.atlassian.net/browse/DSNC-4737
Changelog: https://github.com/pyca/cryptography/blob/37.0.1/CHANGELOG.rst#3701---2022-04-27
Setup file: https://github.com/pyca/cryptography/blob/37.0.1/vectors/setup.cfg (no change since 36.0.1)

The package cryptography-vectors is mentioned inside the packages:
cryptography 

Actions:

Result:

all-succeeded