### PR TITLE
38.0.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: cryptography-vectors

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: cryptography-vectors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "38.0.1" %}
+{% set version = "38.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 0431fd107c1fbad0377704a7051945b3b391169fddc4f6fa0bd4edc6b6e235dd
+  sha256: 6ec62695bec5df810288ddceae998ae691cdb8a162808d6cbc960d3deb9a7db1
 
 build:
   skip: true  # [py<37]


### PR DESCRIPTION
# cryptograph-vectors 38.0.4

upstream: https://github.com/pyca/cryptography/tree/38.0.4
license: https://github.com/pyca/cryptography/blob/38.0.4/LICENSE
changelog: https://cryptography.io/en/latest/changelog/#v38-0-4
jira: https://anaconda.atlassian.net/browse/PKG-901

## Related PRs
- https://github.com/AnacondaRecipes/cryptography-feedstock/pull/16

## Changes
- Update version and SHA

## Notes
- This needs to be updated before or at the same time as https://github.com/AnacondaRecipes/cryptography-feedstock/pull/16
- This release fixes two CVEs: CVE-2022-3602 and CVE-2022-3786.