### PR TITLE
update 39.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "38.0.4" %}
+{% set version = "39.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 6ec62695bec5df810288ddceae998ae691cdb8a162808d6cbc960d3deb9a7db1
+  sha256: 0cbaeb50bdb7f3c9d7a93b26a0462ef6e97c768ca78d902854fe045c30b680c6
 
 build:
   skip: true  # [py<37]


### PR DESCRIPTION
## Version Bump to 39.0.1
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1210)
[Upstream](https://github.com/pyca/cryptography/tree/39.0.1/vectors)
# Changes
- Updated version number and checksum