### PR TITLE
Update 42.0.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/cryptography-42.0.0

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/cryptography-42.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "41.0.7" %}
+{% set version = "42.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 7b36f976b6e58cc1801310e1c93c584c6539d371da7f8538edd8fc463dc80d5b
+  sha256: 8f7568a2cb615aa17193ede1611efd8b11de98827becb7c7005419491db3c998
 
 build:
   skip: true  # [py<37]
@@ -17,9 +17,7 @@ build:
 requirements:
   host:
     - python
-    - pip
-    - setuptools
-    - wheel
+    - flit-core
   run:
     - python
 
@@ -33,17 +31,17 @@ test:
 
 about:
   home: https://github.com/pyca/cryptography
-  license: BSD-3-Clause OR Apache-2.0
-  license_family: BSD
+  license: Apache-2.0 OR BSD-3-Clause
+  license_family: Apache
   license_file:
     - LICENSE
-    - LICENSE.BSD
     - LICENSE.APACHE
+    - LICENSE.BSD
+  summary: Test vectors for cryptography.
   description: |
     This package contains test vectors for the cryptography package.
-  summary: Test vectors for the cryptography package.
-  dev_url: https://github.com/pyca/cryptography/tree/{{ version }}/vectors
-  doc_url: https://cryptography.io/en/{{ version }}/
+  dev_url: https://github.com/pyca/cryptography
+  doc_url: https://cryptography.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 8f7568a2cb615aa17193ede1611efd8b11de98827becb7c7005419491db3c998
+  sha256: adcdccf5d9ee661a9602ad21d2525f678ba07a6e768ce79835994e208bab0e16
 
 build:
   skip: true  # [py<38]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8f7568a2cb615aa17193ede1611efd8b11de98827becb7c7005419491db3c998
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
 
@@ -33,14 +33,11 @@ about:
   home: https://github.com/pyca/cryptography
   license: Apache-2.0 OR BSD-3-Clause
   license_family: Apache
-  license_file:
-    - LICENSE
-    - LICENSE.APACHE
-    - LICENSE.BSD
+  license_file: LICENSE
   summary: Test vectors for cryptography.
   description: |
     This package contains test vectors for the cryptography package.
-  dev_url: https://github.com/pyca/cryptography
+  dev_url: https://github.com/pyca/cryptography/tree/main/vectors
   doc_url: https://cryptography.io/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,6 @@ requirements:
     - python
     - pip
     - flit-core
-    - setuptools
-    - wheel
 
   run:
     - python
@@ -36,8 +34,11 @@ test:
 about:
   home: https://github.com/pyca/cryptography
   license: Apache-2.0 OR BSD-3-Clause
-  license_family: Apache
-  license_file: LICENSE
+  license_family: OTHER
+  license_file:
+    - LICENSE
+    - LICENSE.APACHE
+    - LICENSE.BSD
   summary: Test vectors for cryptography.
   description: |
     This package contains test vectors for the cryptography package.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "42.0.0" %}
+{% set version = "42.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -17,7 +17,11 @@ build:
 requirements:
   host:
     - python
+    - pip
     - flit-core
+    - setuptools
+    - wheel
+
   run:
     - python
 


### PR DESCRIPTION
### cryptography-vectors 42.0.2

**Destination channel:** {defaults}

### Links

- [PKG-4024](https://anaconda.atlassian.net/browse/PKG-4024) 
- [Upstream repository](https://github.com/pyca/cryptography/tree/main/vectors)
- [Upstream changelog/diff](https://cryptography.io/en/latest/changelog/)
- Relevant dependency PRs:
  - This PR is needed for `cryptography 42.0.2` [Jira ticket](https://anaconda.atlassian.net/browse/PKG-4018)

### Explanation of changes:

- Updated `version` and `sha256`
- Updated `license_file` due to not being able to handle multiple licenses
- Added `flit-core`
- Updated urls to not redirect to `en` for non-English readers

[PKG-4024]: https://anaconda.atlassian.net/browse/PKG-4024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ