### PR TITLE
Updated to 43.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "42.0.5" %}
+{% set version = "43.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 505cd5e3b0cb32da1526f07042b7fc38a4b6c356710cb73d2b5f76b037a38ed1
+  sha256: 5c9d09a732d5433cede1542a96ecd70a80e122af047ee7404bcdf1f3ccb8e702
 
 build:
   skip: true  # [py<38]
@@ -19,7 +19,6 @@ requirements:
     - python
     - pip
     - flit-core >=3.2,<4
-
   run:
     - python
 


### PR DESCRIPTION
cryptography-vectors 43.0.0

**Destination channel:** defaults

### Links

- [PKG-5322](https://anaconda.atlassian.net/browse/PKG-5320)
- [Upstream repository](https://github.com/pyca/cryptography/tree/main/vectors)
- [Upstream changelog/diff](https://github.com/pyca/cryptography/blob/43.0.0/CHANGELOG.rst)
- Relevant dependency PRs:
  - AnacondaRecipes/cryptography-feedstock#33

[PKG-5322]: https://anaconda.atlassian.net/browse/PKG-5322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ