### PR TITLE
cryptography-vectors 43.0.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "43.0.0" %}
+{% set version = "43.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,17 +7,19 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 5c9d09a732d5433cede1542a96ecd70a80e122af047ee7404bcdf1f3ccb8e702
+  sha256: ff6a885265f484e8907277614b73e9c774b01658623ad763dde2858188e486b4
 
 build:
   skip: true  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - flit-core >=3.2,<4
   run:
     - python


### PR DESCRIPTION
cryptography-vectors 43.0.1 

**Destination channel:** Defaults

### Links

- [PKG-5801]
- dev_url:        https://github.com/pyca/cryptography/tree/43.0.1/vectors
- conda_forge:    https://github.com/conda-forge/cryptography-vectors-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/cryptography-vectors/43.0.1
- pypi inspector: https://inspector.pypi.io/project/cryptography-vectors/43.0.1

### Explanation of changes:

- new version number
