### PR TITLE
v45.0.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "44.0.1" %}
+{% set version = "45.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: 5a9866b14465dcfaf12bcdfbc3392987bb559f37ac8b8a4c9b6359be7a3d7ea0
+  sha256: b65cebdc334c6b9db8c79081a08253fddf262d009d2c914398edd24a4321db21
 
 build:
   skip: true  # [py<38]


### PR DESCRIPTION
cryptography vectors v45.0.3

**Destination channel:**  defaults

### Links

- [PKG-8327](https://anaconda.atlassian.net/browse/PKG-8327)
- [Upstream repository](https://github.com/pyca/cryptography/tree/45.0.3/vectors)



[PKG-8327]: https://anaconda.atlassian.net/browse/PKG-8327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ