### PR TITLE
cryptography-vectors 45.0.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cryptography-vectors" %}
-{% set version = "45.0.3" %}
+{% set version = "45.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cryptography_vectors-{{ version }}.tar.gz
-  sha256: b65cebdc334c6b9db8c79081a08253fddf262d009d2c914398edd24a4321db21
+  sha256: 1b9e2c1ee94e6b253a03fc0fd749d672ff6e1e48e50dd7af2334fde0303fbbe7
 
 build:
   skip: true  # [py<38]


### PR DESCRIPTION
cryptography-vectors 45.0.5 

**Destination channel:** Defaults

### Links

- [PKG-8919]
- dev_url:        https://github.com/pyca/cryptography/tree/45.0.5
- conda_forge:    https://github.com/conda-forge/cryptography-vectors-feedstock
- pypi:           https://pypi.org/project/cryptography-vectors/45.0.5
- pypi inspector: https://inspector.pypi.io/project/cryptography-vectors/45.0.5

### Explanation of changes:

- new version number


[PKG-8919]: https://anaconda.atlassian.net/browse/PKG-8919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ